### PR TITLE
Fixed bugs in variant lister module

### DIFF
--- a/civic_api_client/evidence_items_lister.py
+++ b/civic_api_client/evidence_items_lister.py
@@ -204,6 +204,10 @@ class EvidenceItemsLister:
                 if self.args.drug:
                     #If drug doesn't exist, add to list of invalids
                     self.check_drug_for_pre(variant_id, variant_detail,evidence_items)
+                # if neither of the flags were specified, do both checks
+                if not (self.args.doid or self.args.drug):
+                    self.check_doid(variant_id, variant_detail, evidence_items)
+                    self.check_drug_for_pre(variant_id, variant_detail,evidence_items)
 
     def get_invalid_eis(self):
         "Return the list of invalid DOIDs"

--- a/civic_api_client/templates/variants.html
+++ b/civic_api_client/templates/variants.html
@@ -14,6 +14,8 @@
         <tr>
             <th>Variant ID</th>
             <th>Name</th>
+            <th>Gene name</th>
+            <th>Error Type</th>
             <th>Ref base</th>
             <th>Variant base</th>
             <th>Chromosome</th>
@@ -28,6 +30,8 @@
         <tr>
             <td> {{variant_details.id}} </td>
             <td> {{variant_details.name}} </td>
+            <td> {{variant_details.gene_name}} </td>
+            <td> {{variant_details.error_type}} </td>
             <td> {{variant_details.ref_base}} </td>
             <td> {{variant_details.var_base}} </td>
             <td> {{variant_details.coordinates['chromosome']}} </td>

--- a/civic_api_client/variants_lister.py
+++ b/civic_api_client/variants_lister.py
@@ -138,12 +138,18 @@ class VariantDetails:
             if self.args.no_coords:
                 if self.error_type == "No coordinate":
                     return True
+                else:
+                    return False
             if self.args.wrong_coords:
                 if self.error_type == "Wrong coordinates":
                     return True
+                else:
+                    return False
             if self.args.wrong_base:
                 if self.error_type == "Wrong base":
                     return True
+                else:
+                    return False
         else:
             satisfies = False
 

--- a/civic_api_client/variants_lister.py
+++ b/civic_api_client/variants_lister.py
@@ -124,9 +124,10 @@ class VariantDetails:
         if self.coordinates:
             
             # Variant length doesn't fit
-            maxvarlength = self.max_var_length()
-            if not maxvarlength: 
-                return False;
+            if self.args.max_var_length:
+                maxvarlength = self.max_var_length()
+                if not maxvarlength: 
+                    return False;
 
             nocoodrs = self.no_coords() 
             wrongcoords = self.wrong_coords()

--- a/civic_api_client/variants_lister.py
+++ b/civic_api_client/variants_lister.py
@@ -40,16 +40,16 @@ class VariantDetails:
         "Parse variant details into class members"
         if 'coordinates' in variant_details:
             self.coordinates = variant_details['coordinates']
+            if 'reference_bases' in variant_details['coordinates']:
+                self.ref_base = variant_details['coordinates']['reference_bases']
+            if 'variant_bases' in variant_details['coordinates']:
+                self.var_base = variant_details['coordinates']['variant_bases']
         if 'name' in variant_details:
             self.name = variant_details['name']
         if 'id' in variant_details:
             self.id = variant_details['id']
         if 'entrez_name' in variant_details:
             self.gene_name = variant_details['entrez_name']
-        if 'reference_bases' in variant_details['coordinates']:
-            self.ref_base = variant_details['coordinates']['reference_bases']
-        if 'variant_bases' in variant_details['coordinates']:
-            self.var_base = variant_details['coordinates']['variant_bases']
         if 'gene_id' in variant_details:
             self.gene_id = variant_details['gene_id']
 

--- a/civic_api_client/variants_lister.py
+++ b/civic_api_client/variants_lister.py
@@ -105,8 +105,7 @@ class VariantDetails:
     #Returns true if variant length within limit or coordinates undefined
     def max_var_length(self):
         "Does the variant have start - stop <= max_var_length"
-        if self.error_type != None:
-            return True
+        rval = False
         if self.coordinates and self.coordinates['stop'] and \
            self.coordinates['start']:
             try:
@@ -114,12 +113,7 @@ class VariantDetails:
                         int(self.coordinates['start']) < \
                         self.args.max_var_length
             except:
-                if self.error_type == None:
-                    self.error_type = "Max variant length"
-                return True
-
-            if rval and self.error_type == None:
-                self.error_type = "Max variant length"
+                return False
 
             return rval
 
@@ -128,11 +122,15 @@ class VariantDetails:
         satisfies = True
 
         if self.coordinates:
+            
+            # Variant length doesn't fit
+            maxvarlength = self.max_var_length()
+            if not maxvarlength: 
+                return False;
+
             nocoodrs = self.no_coords() 
             wrongcoords = self.wrong_coords()
             wrongbase = self.wrong_base()  
-            maxvarlength = self.max_var_length()
-
             if self.error_type == None:
                 return False
 
@@ -144,9 +142,6 @@ class VariantDetails:
                     return True
             if self.args.wrong_base:
                 if self.error_type == "Wrong base":
-                    return True
-            if self.args.max_var_length:
-                if self.error_type == "Max variant length":
                     return True
         else:
             satisfies = False

--- a/civic_api_client/variants_lister.py
+++ b/civic_api_client/variants_lister.py
@@ -61,7 +61,7 @@ class VariantDetails:
         coord = self.coordinates['chromosome'] or \
                 self.coordinates['start'] or \
                 self.coordinates['stop']
-        if not coord and self.error_type == None:   
+        if not coord and self.error_type == None:
             self.error_type = "No coordinate"
         return coord
 
@@ -74,7 +74,7 @@ class VariantDetails:
 
         try:
             rval = (int(self.coordinates['start']) > \
-             int(self.coordinates['stop'])) 
+             int(self.coordinates['stop']))
         except ValueError:
             self.error_type = "Wrong coordinates"
             return True
@@ -122,16 +122,15 @@ class VariantDetails:
         satisfies = True
 
         if self.coordinates:
-            
             # Variant length doesn't fit
             if self.args.max_var_length:
                 maxvarlength = self.max_var_length()
-                if not maxvarlength: 
+                if not maxvarlength:
                     return False;
 
-            nocoodrs = self.no_coords() 
+            nocoodrs = self.no_coords()
             wrongcoords = self.wrong_coords()
-            wrongbase = self.wrong_base()  
+            wrongbase = self.wrong_base()
             if self.error_type == None:
                 return False
 


### PR DESCRIPTION
1. Add Error type report
2. Report all variants with errors without any flag specified (It used to report all variants with or without errors)
3. Fixed the bugs when extracting var_base and ref_base information

The usage is the same with previous version.
